### PR TITLE
workflows: Add some stuff

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -13,7 +13,7 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-   
+
     - name: Docker meta
       id: meta
       uses: docker/metadata-action@v5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
         with:
           node-version: '20'
           registry-url: 'https://registry.npmjs.org'
-          
+
       - name: Install dependencies
         run: |
           sudo apt-get update
@@ -53,7 +53,7 @@ jobs:
 
       - name: Build s-ui & singbox
         run: |
-          export CGO_ENABLED=1
+          export CGO_ENABLED=0
           export GOOS=linux
           export GOARCH=${{ matrix.platform }}
           if [ "${{ matrix.platform }}" == "arm64" ]; then
@@ -71,14 +71,14 @@ jobs:
           #### Build Sing-Box
           git clone -b v1.8.7 https://github.com/SagerNet/sing-box
           cd sing-box
-          go build -tags with_v2ray_api,with_clash_api,with_grpc,with_quic,with_ech -o sing-box ./cmd/sing-box
+          go build -a -tags with_v2ray_api,with_clash_api,with_grpc,with_quic,with_ech -ldflags '-w -extldflags "-static"' -o sing-box ./cmd/sing-box
           cd ..
 
           ### Build s-ui
           cd backend
-          go build -o ../sui main.go
+          go build -a -tags netgo -ldflags '-w -extldflags "-static"' -o ../sui main.go
           cd ..
-          
+
           mkdir s-ui
           cp sui s-ui/
           cp s-ui.service s-ui/
@@ -86,10 +86,10 @@ jobs:
           mkdir s-ui/bin
           cp sing-box/sing-box s-ui/bin/
           cp runSingbox.sh s-ui/bin/
-          
+
       - name: Package
         run: tar -zcvf s-ui-linux-${{ matrix.platform }}.tar.gz s-ui
-        
+
       - name: Upload
         uses: svenstaro/upload-release-action@v2
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,12 +71,12 @@ jobs:
           #### Build Sing-Box
           git clone -b v1.8.7 https://github.com/SagerNet/sing-box
           cd sing-box
-          go build -a -tags with_v2ray_api,with_clash_api,with_grpc,with_quic,with_ech -ldflags '-w -extldflags "-static"' -o sing-box ./cmd/sing-box
+          go build -a -tags with_v2ray_api,with_clash_api,with_grpc,with_quic,with_ech -ldflags '-w -extldflags "-static"' -v -o sing-box ./cmd/sing-box
           cd ..
 
           ### Build s-ui
           cd backend
-          go build -a -tags netgo -ldflags '-w -extldflags "-static"' -o ../sui main.go
+          go build -a -tags netgo -ldflags '-w -extldflags "-static"' -v -o ../sui main.go
           cd ..
 
           mkdir s-ui


### PR DESCRIPTION
Compiling static binary files helps support more Linux versions and more devices as well as limit errors when executing programs.