### PR TITLE
Fixing ss2022 password issue by reversing password array for inbound method handling

### DIFF
--- a/frontend/src/plugins/link.ts
+++ b/frontend/src/plugins/link.ts
@@ -41,6 +41,7 @@ export namespace LinkUtil {
     const userPass = inbound.method == "2022-blake3-aes-128-gcm" ? user.config.shadowsocks16?.password : user.config.shadowsocks?.password
     const password = [userPass]
     if (inbound.method.startsWith('2022')) password.push(inbound.password)
+    password.reverse()
     const params = {
       tfo: inbound.tcp_fast_open? 1 : null,
       network: inbound.network?? null


### PR DESCRIPTION
In this fix, the password array is reversed so that when it is combined once again as a client-side password with `:` joining in, it will be in good manner.