### PR TITLE
feat: scope vless `flow` with `flow_inbound_tags`

### DIFF
--- a/sub/jsonService.go
+++ b/sub/jsonService.go
@@ -156,10 +156,30 @@ func (j *JsonService) getOutbounds(clientConfig json.RawMessage, inbounds []*mod
 			}
 			userPass = append(userPass, pass)
 			outbound["password"] = strings.Join(userPass, ":")
+		} else if protocol == "vless" {
+			config, _ := configs[protocol].(map[string]interface{})
+			for key, value := range config {
+				if key == "name" || key == "flow_inbound_tags" || key == "alterId" || (key == "flow" && inData.TlsId == 0) {
+					continue
+				}
+				if key == "flow" {
+					if flowInboundTags, ok := config["flow_inbound_tags"].([]interface{}); ok && len(flowInboundTags) > 0 {
+						for _, tag := range flowInboundTags {
+							if tag.(string) == inData.Tag {
+								outbound[key] = value
+							}
+						}
+					} else {
+						outbound[key] = value
+					}
+					continue
+				}
+				outbound[key] = value
+			}
 		} else { // Other protocols
 			config, _ := configs[protocol].(map[string]interface{})
 			for key, value := range config {
-				if key == "name" || key == "alterId" || (key == "flow" && inData.TlsId == 0) {
+				if key == "name" || key == "alterId" {
 					continue
 				}
 				outbound[key] = value

--- a/util/genLink.go
+++ b/util/genLink.go
@@ -368,8 +368,18 @@ func vlessLink(
 		params := baseParams
 		if tls, ok := addr["tls"].(map[string]interface{}); ok && tls["enabled"].(bool) {
 			getTlsParams(&params, tls, "allowInsecure")
-			if flow, ok := userConfig["flow"].(string); ok {
-				params["flow"] = flow
+			if flow, ok := userConfig["flow"].(string); ok && flow != "" {
+				if flowInboundTags, ok := userConfig["flow_inbound_tags"].([]interface{}); ok && len(flowInboundTags) > 0 {
+					for _, tag := range flowInboundTags {
+						if tag.(string) == inbound["tag"].(string) {
+							params["flow"] = flow
+							break
+						}
+					}
+				} else {
+					// if flow_inbound_tags is empty, apply to all
+					params["flow"] = flow
+				}
 			}
 		}
 		port, _ := addr["server_port"].(float64)


### PR DESCRIPTION
Problem:
- Previously, if a user's `flow` was specified, all of that user's `vless` outbounds that use TLS would inherit and use the same `flow`. This made it impossible to scope `flow` to specific inbounds and could cause `flow` to appear on unintended inbounds.

Solution:
- This PR adds `flow_inbound_tags` to allow admins to scope a user's `flow` to specific inbound tags. Behavior rules:
	- If `flow` is non-empty and `flow_inbound_tags` is empty, behavior is unchanged: all of the user's TLS `vless` outbounds will use `flow`.
	- If `flow` is non-empty and `flow_inbound_tags` contains tags, only TLS `vless` outbounds whose inbound tag matches one of the listed tags will have `flow` applied.