### PR TITLE
feat(sub): add HEAD method support for sub resource

### DIFF
--- a/sub/subHandler.go
+++ b/sub/subHandler.go
@@ -21,6 +21,7 @@ func NewSubHandler(g *gin.RouterGroup) {
 
 func (s *SubHandler) initRouter(g *gin.RouterGroup) {
 	g.GET("/:subid", s.subs)
+	g.HEAD("/:subid", s.subs)
 }
 
 func (s *SubHandler) subs(c *gin.Context) {
@@ -53,6 +54,12 @@ func (s *SubHandler) subs(c *gin.Context) {
 	c.Writer.Header().Set("Subscription-Userinfo", headers[0])
 	c.Writer.Header().Set("Profile-Update-Interval", headers[1])
 	c.Writer.Header().Set("Profile-Title", headers[2])
+
+	// For HEAD requests
+	if c.Request.Method == "HEAD" {
+		c.Status(200)
+		return
+	}
 
 	c.String(200, *result)
 }


### PR DESCRIPTION
# Subscription HEAD Request Support

## Overview

The feature allows clients (such as Karing) to retrieve traffic and expiration information without downloading the full subscription content, reducing bandwidth usage and improving response times.

## Problem Statement

Previously, the subscription system only supported GET requests for retrieving subscription data. When clients needed to check traffic usage or expiration dates, they had to perform a full GET request, downloading all configuration data even if they only needed metadata.

## Solution

Added support for HEAD requests to subscription endpoints, allowing clients to retrieve only the headers containing traffic and expiration information without the response body.

## Implementation Details

### Modified Files

1. `sub/subHandler.go` - Added HEAD route registration and logic to handle HEAD requests

### Changes Made

1. Added HEAD route handler registration:
   ```go
   g.HEAD("/:subid", s.subs)
   ```

2. Modified the `subs` function to detect HEAD requests and return only headers:
   ```go
   // For HEAD requests, only send headers without body
   if c.Request.Method == "HEAD" {
       c.Status(200)
       return
   }
   ```

## Usage

Clients can now make HEAD requests to subscription endpoints:

```
HEAD /sub/{sub_id} HTTP/1.1
Host: your-domain.com
User-Agent: Karing/1.0
```

The response will contain headers with traffic and expiration information:

```
HTTP/1.1 200 OK
Subscription-Userinfo: upload=123456; download=789012; total=1000000000; expire=1789456230
Profile-Update-Interval: 24
Profile-Title: client-name
```

### Header Information

- `Subscription-Userinfo`: Contains traffic and expiration data
  - `upload`: Uploaded bytes
  - `download`: Downloaded bytes
  - `total`: Total traffic allowance (if set)
  - `expire`: Expiration timestamp (Unix format)
- `Profile-Update-Interval`: Recommended update interval in hours
- `Profile-Title`: Client name/title

## Benefits

1. **Reduced Bandwidth**: Clients can retrieve metadata without downloading full configuration
2. **Faster Responses**: HEAD requests are processed faster than GET requests
3. **Improved Efficiency**: More efficient for periodic status checks
4. **Compatibility**: Maintains backward compatibility with existing GET requests

## Compatibility

This change is fully backward compatible. Existing clients using GET requests will continue to work as before, while new clients can take advantage of the more efficient HEAD request option.

<img width="1260" height="988" alt="Screenshot_20251205_213529" src="https://github.com/user-attachments/assets/25986cc8-5daa-4b45-9d5e-756bae649df0" />
