### PR TITLE
fix: correct servername handling for vless/vmess

### DIFF
--- a/sub/clashService.go
+++ b/sub/clashService.go
@@ -251,10 +251,10 @@ func (s *ClashService) ConvertToClashMeta(outbounds *[]map[string]interface{}) (
 				}
 			}
 			if sni, ok := tls["server_name"].(string); ok {
-				if t == "http" {
-					proxy["sni"] = sni
-				} else {
+				if t == "vless" || t == "vmess" {
 					proxy["servername"] = sni
+				} else {
+					proxy["sni"] = sni
 				}
 			}
 			if insecure, ok := tls["insecure"].(bool); ok && insecure {


### PR DESCRIPTION
Use `servername` instead of `sni` for vless/vmess protocols.

According to mihomo documentation:
https://wiki.metacubex.one/en/config/proxies/tls/

> The server name indication, referred to as servername in VMess/VLESS. If left empty, it defaults to the address in server.

This change ensures correct TLS field mapping for these protocols while keeping existing behavior unchanged for others.