### PR TITLE
fix: remove default up_mbps and down_mbps fallback to allow BBR

### DIFF
--- a/sub/clashService.go
+++ b/sub/clashService.go
@@ -167,13 +167,9 @@ func (s *ClashService) ConvertToClashMeta(outbounds *[]map[string]interface{}) (
 		case "hysteria", "hysteria2":
 			if _, ok := obMap["up_mbps"].(float64); ok {
 				proxy["up"] = obMap["up_mbps"]
-			} else {
-				proxy["up"] = 1000
 			}
 			if _, ok := obMap["down_mbps"].(float64); ok {
 				proxy["down"] = obMap["down_mbps"]
-			} else {
-				proxy["down"] = 1000
 			}
 			if t == "hysteria" {
 				proxy["auth-str"] = obMap["auth_str"]


### PR DESCRIPTION
Remove default fallback when `up_mbps` or `down_mbps` is not provided.

By leaving the field unset, the underlying implementation can use BBR instead of Brutal.

This avoids unintentionally capping upload speed and aligns with expected behavior when no explicit limit is configured.