### PR TITLE
feature: support setting domain and cert/key file paths via CLI and shell script

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -23,12 +23,18 @@ func ParseCmd() {
 	var path string
 	var subPort int
 	var subPath string
+	var domain string
+	var certFile string
+	var keyFile string
 	var reset bool
 	var show bool
 	settingCmd.BoolVar(&reset, "reset", false, "reset all settings")
 	settingCmd.BoolVar(&show, "show", false, "show current settings")
 	settingCmd.IntVar(&port, "port", 0, "set panel port")
 	settingCmd.StringVar(&path, "path", "", "set panel path")
+	settingCmd.StringVar(&domain, "domain", "", "set panel domain")
+	settingCmd.StringVar(&certFile, "certFile", "", "set panel cert file path")
+	settingCmd.StringVar(&keyFile, "keyFile", "", "set panel key file path")
 	settingCmd.IntVar(&subPort, "subPort", 0, "set sub port")
 	settingCmd.StringVar(&subPath, "subPath", "", "set sub path")
 
@@ -102,7 +108,7 @@ func ParseCmd() {
 		case reset:
 			resetSetting()
 		default:
-			updateSetting(port, path, subPort, subPath)
+			updateSetting(port, path, domain, certFile, keyFile, subPort, subPath)
 			showSetting()
 		}
 	default:

--- a/cmd/setting.go
+++ b/cmd/setting.go
@@ -31,7 +31,7 @@ func resetSetting() {
 	}
 }
 
-func updateSetting(port int, path string, subPort int, subPath string) {
+func updateSetting(port int, path string, domain string, certFile string, keyFile string, subPort int, subPath string) {
 	err := database.InitDB(config.GetDBPath())
 	if err != nil {
 		fmt.Println(err)
@@ -54,6 +54,30 @@ func updateSetting(port int, path string, subPort int, subPath string) {
 			fmt.Println("set path failed:", err)
 		} else {
 			fmt.Println("set path success")
+		}
+	}
+	if domain != "" {
+		err := settingService.SetWebDomain(domain)
+		if err != nil {
+			fmt.Println("set domain failed:", err)
+		} else {
+			fmt.Println("set domain success")
+		}
+	}
+	if certFile != "" {
+		err := settingService.SetCertFile(certFile)
+		if err != nil {
+			fmt.Println("set cert file failed:", err)
+		} else {
+			fmt.Println("set cert file success")
+		}
+	}
+	if keyFile != "" {
+		err := settingService.SetKeyFile(keyFile)
+		if err != nil {
+			fmt.Println("set key file failed:", err)
+		} else {
+			fmt.Println("set key file success")
 		}
 	}
 	if subPort > 0 {
@@ -93,6 +117,12 @@ func showSetting() {
 	}
 	if (*allSetting)["webDomain"] != "" {
 		fmt.Println("\tPanel Domain:\t", (*allSetting)["webDomain"])
+	}
+	if (*allSetting)["webCertFile"] != "" {
+		fmt.Println("\tPanel Cert:\t", (*allSetting)["webCertFile"])
+	}
+	if (*allSetting)["webKeyFile"] != "" {
+		fmt.Println("\tPanel Key:\t", (*allSetting)["webKeyFile"])
 	}
 	if (*allSetting)["webURI"] != "" {
 		fmt.Println("\tPanel URI:\t", (*allSetting)["webURI"])

--- a/s-ui.sh
+++ b/s-ui.sh
@@ -166,6 +166,12 @@ set_setting() {
     read config_port
     echo -e "Enter the ${yellow}panel path${plain} (leave blank for existing/default value):"
     read config_path
+    echo -e "Enter the ${yellow}panel domain${plain} (leave blank for existing/default value):"
+    read config_domain
+    echo -e "Enter the ${yellow}panel cert file path${plain} (leave blank for existing/default value):"
+    read config_certFile
+    echo -e "Enter the ${yellow}panel key file path${plain} (leave blank for existing/default value):"
+    read config_keyFile
 
     echo -e "Enter the ${yellow}subscription port${plain} (leave blank for existing/default value):"
     read config_subPort
@@ -176,6 +182,9 @@ set_setting() {
     params=""
     [ -z "$config_port" ] || params="$params -port $config_port"
     [ -z "$config_path" ] || params="$params -path $config_path"
+    [ -z "$config_domain" ] || params="$params -domain $config_domain"
+    [ -z "$config_certFile" ] || params="$params -certFile $config_certFile"
+    [ -z "$config_keyFile" ] || params="$params -keyFile $config_keyFile"
     [ -z "$config_subPort" ] || params="$params -subPort $config_subPort"
     [ -z "$config_subPath" ] || params="$params -subPath $config_subPath"
     /usr/local/s-ui/sui setting ${params}

--- a/service/setting.go
+++ b/service/setting.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
 	"runtime"
 	"strconv"
@@ -183,6 +184,10 @@ func (s *SettingService) GetWebDomain() (string, error) {
 	return s.getString("webDomain")
 }
 
+func (s *SettingService) SetWebDomain(webDomain string) error {
+	return s.setString("webDomain", webDomain)
+}
+
 func (s *SettingService) GetPort() (int, error) {
 	return s.getInt("webPort")
 }
@@ -195,8 +200,26 @@ func (s *SettingService) GetCertFile() (string, error) {
 	return s.getString("webCertFile")
 }
 
+func (s *SettingService) SetCertFile(certFile string) error {
+	if certFile != "" {
+		if err := s.fileExists(certFile); err != nil {
+			return fmt.Errorf("cert file %s does not exist", certFile)
+		}
+	}
+	return s.setString("webCertFile", certFile)
+}
+
 func (s *SettingService) GetKeyFile() (string, error) {
 	return s.getString("webKeyFile")
+}
+
+func (s *SettingService) SetKeyFile(keyFile string) error {
+	if keyFile != "" {
+		if err := s.fileExists(keyFile); err != nil {
+			return fmt.Errorf("key file %s does not exist", keyFile)
+		}
+	}
+	return s.setString("webKeyFile", keyFile)
 }
 
 func (s *SettingService) GetWebPath() (string, error) {


### PR DESCRIPTION
## Summary

Add CLI and shell script support for configuring `webDomain`, TLS certificate file path, and key file path.

## Changes

### service/setting.go
- Add `SetCertFile(certFile string)` method with file existence validation before saving
- Add `SetKeyFile(keyFile string)` method with file existence validation before saving

### cmd/cmd.go
- Add `-domain`, `-certFile`, and `-keyFile` string flags to the `setting` subcommand
- Pass new parameters to `updateSetting()`

### cmd/setting.go
- Update `updateSetting()` signature to accept `domain`, `certFile`, and `keyFile` parameters
- Add domain/cert/key file setting logic with error handling
- Display `Panel Domain`, `Panel Cert`, and `Panel Key` paths in `showSetting()` output

### s-ui.sh
- Add interactive prompts for panel domain, cert file path, and key file path in `set_setting()`
- Pass `-domain`, `-certFile`, and `-keyFile` flags to the `sui setting` command

## Usage

### CLI
```bash
# Set domain
s-ui setting -domain example.com

# Set cert and key file paths
s-ui setting -certFile /root/cert/fullchain.pem -keyFile /root/cert/privkey.pem

# Combine with other settings
s-ui setting -domain example.com -certFile /root/cert/fullchain.pem -keyFile /root/cert/privkey.pem -port 443

# View current settings
s-ui setting -show
```

### Interactive menu (s-ui.sh)
The 'Set Panel settings' option now prompts for domain, cert file path, and key file path.
