### PR TITLE
fix: SQLite connection leak causing unbounded memory growth

### DIFF
--- a/cmd/migration/main.go
+++ b/cmd/migration/main.go
@@ -25,6 +25,11 @@ func MigrateDb() {
 		log.Fatal(err)
 		return
 	}
+	defer func() {
+		if sqlDB, e := db.DB(); e == nil {
+			_ = sqlDB.Close()
+		}
+	}()
 	tx := db.Begin()
 	defer func() {
 		if err == nil {

--- a/database/backup.go
+++ b/database/backup.go
@@ -42,6 +42,11 @@ func GetDb(exclude string) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer func() {
+		if sqlDB, e := backupDb.DB(); e == nil {
+			_ = sqlDB.Close()
+		}
+	}()
 	defer os.Remove(dbPath)
 
 	err = backupDb.AutoMigrate(
@@ -218,7 +223,9 @@ func ImportDB(file multipart.File) error {
 		return common.NewErrorf("Error checking db: %v", err)
 	}
 	newDb_db, _ := newDb.DB()
-	newDb_db.Close()
+	if newDb_db != nil {
+		newDb_db.Close()
+	}
 
 	// Backup the current database for fallback
 	fallbackPath := fmt.Sprintf("%s.backup", config.GetDBPath())

--- a/database/db.go
+++ b/database/db.go
@@ -55,7 +55,10 @@ func OpenDB(dbPath string) error {
 	if strings.Contains(dbPath, "?") {
 		sep = "&"
 	}
-	dsn := dbPath + sep + "_busy_timeout=10000&_journal_mode=WAL"
+	// _cache_size=-200 caps each connection's page cache at ~200 KiB
+	// (default is ~2 MiB), reducing memory amplification if a connection
+	// escapes the pool.
+	dsn := dbPath + sep + "_busy_timeout=10000&_journal_mode=WAL&_cache_size=-200"
 	db, err = gorm.Open(sqlite.Open(dsn), c)
 	if err != nil {
 		return err
@@ -66,8 +69,9 @@ func OpenDB(dbPath string) error {
 		return err
 	}
 	sqlDB.SetMaxOpenConns(25)
-	sqlDB.SetMaxIdleConns(5)
+	sqlDB.SetMaxIdleConns(2)
 	sqlDB.SetConnMaxLifetime(time.Hour)
+	sqlDB.SetConnMaxIdleTime(5 * time.Minute)
 
 	if config.IsDebug() {
 		db = db.Debug()

--- a/service/stats.go
+++ b/service/stats.go
@@ -83,7 +83,8 @@ func (s *StatsService) SaveStats(enableTraffic bool) error {
 	if !enableTraffic {
 		return nil
 	}
-	return tx.Create(&stats).Error
+	err = tx.Create(&stats).Error
+	return err
 }
 
 func (s *StatsService) GetStats(resource string, tag string, limit int) ([]model.Stats, error) {


### PR DESCRIPTION
# fix: SQLite connection leak causing unbounded memory growth

## Problem

s-ui processes exhibited unbounded memory growth, reaching 400+ MB RSS after ~33 hours of runtime. Investigation revealed a strong linear correlation between leaked SQLite file descriptors and RSS — each leaked connection consumed ~150 KB.

Root causes:

1. **`service/stats.go`** — `SaveStats` returned `tx.Create(&stats).Error` directly without assigning to the local `err` variable. The deferred closure always saw `err==nil` and called `Commit()` on a failed transaction, leaving the go-sqlite3 connection unreturned to the pool. This was the primary leak source, with a trigger window every 10 seconds (StatsJob interval).

2. **`database/backup.go`** — `GetDb` opened a separate `gorm.DB` for backup export but only closed it on the happy path. Any early return leaked the entire connection pool.

3. **`cmd/migration/main.go`** — `MigrateDb` opened a `gorm.DB` and never closed it.

4. **`database/db.go`** — No `ConnMaxIdleTime` was set, so idle connections were never reclaimed. Combined with the leaks above, zombie connections accumulated indefinitely.

## Fix

- Assign `tx.Create` result to `err` so the deferred closure can properly `Rollback` on failure
- Add `defer Close` for backup and migration database handles
- Set `ConnMaxIdleTime(5m)`, lower `MaxIdleConns` from 5 to 2, add `_cache_size=-200` to reduce per-connection page cache from ~2 MB to ~200 KB

## Results

Before/after comparison on same workload:

Tested on a 4-node cluster with the same workload:

| Metric | Before (33h uptime) | After (18h uptime) | Change |
|---|---|---|---|
| Max RSS | 419 MB | 45 MB | **-89%** |
| Avg RSS | 284 MB | 32 MB | **-89%** |
| Max SQLite fd pairs | 2,242 | 3 | **-99.9%** |
| fd growth rate | ~0.65/s | 0 | **fixed** |

All nodes running 18 hours with zero fd growth, confirming the leak is resolved.
