### PR TITLE
fix(vless): preserve vision flow for tcp tls

### DIFF
--- a/service/inbounds.go
+++ b/service/inbounds.go
@@ -10,6 +10,7 @@ import (
 	"github.com/alireza0/s-ui/database/model"
 	"github.com/alireza0/s-ui/util"
 	"github.com/alireza0/s-ui/util/common"
+	protocolutil "github.com/alireza0/s-ui/util/protocol"
 
 	"gorm.io/gorm"
 )
@@ -275,8 +276,7 @@ func (s *InboundService) fetchUsers(db *gorm.DB, inboundType string, condition s
 	}
 	stripVision := false
 	if inboundType == "vless" {
-		transport, _ := inbound["transport"].(map[string]interface{})
-		stripVision = len(transport) > 0 || inbound["tls"] == nil
+		stripVision = !protocolutil.VlessVisionFlowAllowed(inbound["tls"] != nil, inbound["transport"])
 	}
 
 	var usersJson []json.RawMessage

--- a/service/inbounds.go
+++ b/service/inbounds.go
@@ -276,7 +276,7 @@ func (s *InboundService) fetchUsers(db *gorm.DB, inboundType string, condition s
 	}
 	stripVision := false
 	if inboundType == "vless" {
-		stripVision = !protocolutil.VlessVisionFlowAllowed(inbound["tls"] != nil, inbound["transport"])
+		stripVision = !protocolutil.VlessVisionFlowAllowed(protocolutil.TLSEnabled(inbound["tls"]), inbound["transport"])
 	}
 
 	var usersJson []json.RawMessage

--- a/service/inbounds_vless_test.go
+++ b/service/inbounds_vless_test.go
@@ -1,0 +1,102 @@
+package service
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/alireza0/s-ui/database/model"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func TestVlessVisionFlowWithTcpTransport(t *testing.T) {
+	testVlessVisionFlowWithTcpTransport(t, map[string]interface{}{"enabled": true})
+}
+
+func TestVlessVisionFlowWithRealityTcpTransport(t *testing.T) {
+	testVlessVisionFlowWithTcpTransport(t, map[string]interface{}{
+		"enabled": true,
+		"reality": map[string]interface{}{
+			"enabled": true,
+		},
+	})
+}
+
+func testVlessVisionFlowWithTcpTransport(t *testing.T, tls map[string]interface{}) {
+	t.Helper()
+	user := fetchVlessUser(t, tls, map[string]interface{}{"type": "tcp"})
+	if got := user["flow"]; got != "xtls-rprx-vision" {
+		t.Fatalf("flow was changed: %q", got)
+	}
+}
+
+func fetchVlessUser(t *testing.T, tls map[string]interface{}, transport map[string]interface{}) map[string]string {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := db.AutoMigrate(&model.Client{}); err != nil {
+		t.Fatal(err)
+	}
+
+	clientConfig := json.RawMessage(`{"vless":{"uuid":"11111111-1111-1111-1111-111111111111","flow":"xtls-rprx-vision"}}`)
+	if err := db.Create(&model.Client{
+		Enable: true,
+		Config: clientConfig,
+	}).Error; err != nil {
+		t.Fatal(err)
+	}
+
+	users, err := (&InboundService{}).fetchUsers(db, "vless", "true", map[string]interface{}{
+		"tls":       tls,
+		"transport": transport,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(users) != 1 {
+		t.Fatalf("got %d users", len(users))
+	}
+	var user map[string]string
+	if err := json.Unmarshal(users[0], &user); err != nil {
+		t.Fatal(err)
+	}
+	return user
+}
+
+func TestVlessVisionFlowWithNonTcpTransport(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := db.AutoMigrate(&model.Client{}); err != nil {
+		t.Fatal(err)
+	}
+
+	clientConfig := json.RawMessage(`{"vless":{"uuid":"11111111-1111-1111-1111-111111111111","flow":"xtls-rprx-vision"}}`)
+	if err := db.Create(&model.Client{
+		Enable: true,
+		Config: clientConfig,
+	}).Error; err != nil {
+		t.Fatal(err)
+	}
+
+	users, err := (&InboundService{}).fetchUsers(db, "vless", "true", map[string]interface{}{
+		"tls":       map[string]interface{}{"enabled": true},
+		"transport": map[string]interface{}{"type": "grpc"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(users) != 1 {
+		t.Fatalf("got %d users", len(users))
+	}
+	var user map[string]string
+	if err := json.Unmarshal(users[0], &user); err != nil {
+		t.Fatal(err)
+	}
+	if got := user["flow"]; got != "" {
+		t.Fatalf("flow was not stripped: %q", got)
+	}
+}

--- a/service/inbounds_vless_test.go
+++ b/service/inbounds_vless_test.go
@@ -22,6 +22,13 @@ func TestVlessVisionFlowWithRealityTcpTransport(t *testing.T) {
 	})
 }
 
+func TestVlessVisionFlowWithDisabledTLSTcpTransport(t *testing.T) {
+	user := fetchVlessUser(t, map[string]interface{}{"enabled": false}, map[string]interface{}{"type": "tcp"})
+	if got := user["flow"]; got != "" {
+		t.Fatalf("flow was not stripped: %q", got)
+	}
+}
+
 func testVlessVisionFlowWithTcpTransport(t *testing.T, tls map[string]interface{}) {
 	t.Helper()
 	user := fetchVlessUser(t, tls, map[string]interface{}{"type": "tcp"})

--- a/sub/jsonService.go
+++ b/sub/jsonService.go
@@ -1,7 +1,6 @@
 package sub
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 	"strings"
@@ -10,6 +9,7 @@ import (
 	"github.com/alireza0/s-ui/database/model"
 	"github.com/alireza0/s-ui/service"
 	"github.com/alireza0/s-ui/util"
+	protocolutil "github.com/alireza0/s-ui/util/protocol"
 )
 
 const defaultJson = `
@@ -155,7 +155,7 @@ func (j *JsonService) getOutbounds(clientConfig json.RawMessage, inbounds []*mod
 					continue
 				}
 				if key == "flow" {
-					if inData.TlsId == 0 || bytes.Contains(inData.Options, []byte(`"transport"`)) {
+					if protocol == "vless" && !protocolutil.VlessVisionFlowAllowedFromOptions(inData.TlsId > 0, inData.Options) {
 						continue
 					}
 				}

--- a/sub/jsonService.go
+++ b/sub/jsonService.go
@@ -155,7 +155,7 @@ func (j *JsonService) getOutbounds(clientConfig json.RawMessage, inbounds []*mod
 					continue
 				}
 				if key == "flow" {
-					if protocol == "vless" && !protocolutil.VlessVisionFlowAllowedFromOptions(inData.TlsId > 0, inData.Options) {
+					if protocol == "vless" && !protocolutil.VlessVisionFlowAllowedFromOptions(protocolutil.TLSEnabled(outbound["tls"]), inData.Options) {
 						continue
 					}
 				}

--- a/sub/json_vless_test.go
+++ b/sub/json_vless_test.go
@@ -31,6 +31,14 @@ func TestJsonOutboundsStripVlessVisionFlowWithoutTLS(t *testing.T) {
 	}
 }
 
+func TestJsonOutboundsStripVlessVisionFlowWithDisabledTLS(t *testing.T) {
+	outbound := vlessOutboundFromOptions(t, json.RawMessage(`{"transport":{}}`), map[string]interface{}{"enabled": false})
+
+	if got, ok := outbound["flow"]; ok {
+		t.Fatalf("flow was not stripped: %v", got)
+	}
+}
+
 func vlessOutboundFromOptions(t *testing.T, options json.RawMessage, tls map[string]interface{}) map[string]interface{} {
 	t.Helper()
 

--- a/sub/json_vless_test.go
+++ b/sub/json_vless_test.go
@@ -1,0 +1,71 @@
+package sub
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/alireza0/s-ui/database/model"
+)
+
+func TestJsonOutboundsPreserveVlessVisionFlowForDefaultTcpTLS(t *testing.T) {
+	outbound := vlessOutboundFromOptions(t, json.RawMessage(`{"transport":{}}`), map[string]interface{}{"enabled": true})
+
+	if got := outbound["flow"]; got != "xtls-rprx-vision" {
+		t.Fatalf("flow was not preserved: %v", got)
+	}
+}
+
+func TestJsonOutboundsStripVlessVisionFlowForGrpcTLS(t *testing.T) {
+	outbound := vlessOutboundFromOptions(t, json.RawMessage(`{"transport":{"type":"grpc"}}`), map[string]interface{}{"enabled": true})
+
+	if got, ok := outbound["flow"]; ok {
+		t.Fatalf("flow was not stripped: %v", got)
+	}
+}
+
+func TestJsonOutboundsStripVlessVisionFlowWithoutTLS(t *testing.T) {
+	outbound := vlessOutboundFromOptions(t, json.RawMessage(`{"transport":{}}`), nil)
+
+	if got, ok := outbound["flow"]; ok {
+		t.Fatalf("flow was not stripped: %v", got)
+	}
+}
+
+func vlessOutboundFromOptions(t *testing.T, options json.RawMessage, tls map[string]interface{}) map[string]interface{} {
+	t.Helper()
+
+	inbound := &model.Inbound{
+		TlsId:   0,
+		Options: options,
+		Addrs:   json.RawMessage(`[]`),
+		OutJson: json.RawMessage(`{"type":"vless","tag":"vless-test","server":"example.com","server_port":443,"transport":{}}`),
+	}
+	if tls != nil {
+		outbound := map[string]interface{}{
+			"type":        "vless",
+			"tag":         "vless-test",
+			"server":      "example.com",
+			"server_port": float64(443),
+			"tls":         tls,
+			"transport":   map[string]interface{}{},
+		}
+		outJson, err := json.Marshal(outbound)
+		if err != nil {
+			t.Fatal(err)
+		}
+		inbound.TlsId = 1
+		inbound.OutJson = outJson
+	}
+
+	outbounds, _, err := (&JsonService{}).getOutbounds(
+		json.RawMessage(`{"vless":{"uuid":"11111111-1111-1111-1111-111111111111","flow":"xtls-rprx-vision"}}`),
+		[]*model.Inbound{inbound},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(*outbounds) != 1 {
+		t.Fatalf("got %d outbounds", len(*outbounds))
+	}
+	return (*outbounds)[0]
+}

--- a/util/protocol/vless.go
+++ b/util/protocol/vless.go
@@ -1,0 +1,26 @@
+package protocol
+
+import "encoding/json"
+
+func VlessVisionFlowAllowed(hasTLS bool, transport interface{}) bool {
+	if !hasTLS {
+		return false
+	}
+	transportMap, ok := transport.(map[string]interface{})
+	if !ok {
+		return true
+	}
+	transportType, _ := transportMap["type"].(string)
+	return transportType == "" || transportType == "tcp"
+}
+
+func VlessVisionFlowAllowedFromOptions(hasTLS bool, options json.RawMessage) bool {
+	if !hasTLS {
+		return false
+	}
+	var raw map[string]interface{}
+	if err := json.Unmarshal(options, &raw); err != nil {
+		return true
+	}
+	return VlessVisionFlowAllowed(true, raw["transport"])
+}

--- a/util/protocol/vless.go
+++ b/util/protocol/vless.go
@@ -2,6 +2,15 @@ package protocol
 
 import "encoding/json"
 
+func TLSEnabled(tls interface{}) bool {
+	tlsMap, ok := tls.(map[string]interface{})
+	if !ok {
+		return false
+	}
+	enabled, _ := tlsMap["enabled"].(bool)
+	return enabled
+}
+
 func VlessVisionFlowAllowed(hasTLS bool, transport interface{}) bool {
 	if !hasTLS {
 		return false

--- a/util/protocol/vless_test.go
+++ b/util/protocol/vless_test.go
@@ -5,6 +5,27 @@ import (
 	"testing"
 )
 
+func TestTLSEnabled(t *testing.T) {
+	tests := []struct {
+		name string
+		tls  interface{}
+		want bool
+	}{
+		{name: "missing tls", want: false},
+		{name: "enabled tls", tls: map[string]interface{}{"enabled": true}, want: true},
+		{name: "disabled tls", tls: map[string]interface{}{"enabled": false}, want: false},
+		{name: "missing enabled", tls: map[string]interface{}{}, want: false},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := TLSEnabled(test.tls); got != test.want {
+				t.Fatalf("got %v, want %v", got, test.want)
+			}
+		})
+	}
+}
+
 func TestVlessVisionFlowAllowed(t *testing.T) {
 	tests := []struct {
 		name      string

--- a/util/protocol/vless_test.go
+++ b/util/protocol/vless_test.go
@@ -1,0 +1,51 @@
+package protocol
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestVlessVisionFlowAllowed(t *testing.T) {
+	tests := []struct {
+		name      string
+		hasTLS    bool
+		transport interface{}
+		want      bool
+	}{
+		{name: "no tls", hasTLS: false, want: false},
+		{name: "no transport", hasTLS: true, want: true},
+		{name: "empty transport", hasTLS: true, transport: map[string]interface{}{}, want: true},
+		{name: "tcp transport", hasTLS: true, transport: map[string]interface{}{"type": "tcp"}, want: true},
+		{name: "grpc transport", hasTLS: true, transport: map[string]interface{}{"type": "grpc"}, want: false},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := VlessVisionFlowAllowed(test.hasTLS, test.transport); got != test.want {
+				t.Fatalf("got %v, want %v", got, test.want)
+			}
+		})
+	}
+}
+
+func TestVlessVisionFlowAllowedFromOptions(t *testing.T) {
+	tests := []struct {
+		name    string
+		hasTLS  bool
+		options json.RawMessage
+		want    bool
+	}{
+		{name: "no tls", hasTLS: false, options: json.RawMessage(`{"transport":{"type":"tcp"}}`), want: false},
+		{name: "tcp transport", hasTLS: true, options: json.RawMessage(`{"transport":{"type":"tcp"}}`), want: true},
+		{name: "grpc transport", hasTLS: true, options: json.RawMessage(`{"transport":{"type":"grpc"}}`), want: false},
+		{name: "empty transport", hasTLS: true, options: json.RawMessage(`{"transport":{}}`), want: true},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := VlessVisionFlowAllowedFromOptions(test.hasTLS, test.options); got != test.want {
+				t.Fatalf("got %v, want %v", got, test.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## English

### Problem

#1127 limits VLESS Vision flow so `xtls-rprx-vision` is not applied to unsupported transports such as gRPC.

However, the current check removes `flow` whenever the inbound has a `transport` field. This is too broad because `transport: {}` and `transport: {"type":"tcp"}` both represent the default TCP transport, where VLESS + TLS/Reality should still keep `xtls-rprx-vision`.

This breaks Clash/FlClash subscriptions for VLESS + TLS/Reality nodes because the generated outbound loses its `flow`.

### Solution

Use a protocol helper to decide whether VLESS Vision flow is allowed:

1. Keep `flow` when TLS/Reality is enabled and transport is default TCP (`nil`, `{}`, or `type: tcp`)
2. Strip `flow` when TLS is not enabled
3. Strip `flow` for non-TCP transports such as gRPC

Apply the same check in both inbound user generation and JSON/Clash subscription generation.

### Related

- Fixes #1156
- Refines #1127

### Test Coverage

15 cases covering service inbound users, subscription outbounds, and protocol helper behavior.

- VLESS + TLS + TCP keeps Vision flow
- VLESS + Reality + TCP keeps Vision flow
- VLESS + gRPC strips Vision flow
- VLESS without TLS strips Vision flow
- Default/empty transport is treated as TCP

`go test ./...`

---

## 中文

### 问题背景

#1127 的目标是限制 VLESS Vision flow，避免 `xtls-rprx-vision` 被应用到 gRPC 等不支持的传输方式上。

但当前判断只要入站存在 `transport` 字段就会移除 `flow`，这个条件过宽。因为 `transport: {}` 和 `transport: {"type":"tcp"}` 都表示默认 TCP 传输，在 VLESS + TLS/Reality 场景下仍然应该保留 `xtls-rprx-vision`。

这会导致 Clash/FlClash 订阅里的 VLESS + TLS/Reality 节点丢失 `flow`，客户端无法按 Vision 方式连接。

### 修改

新增协议 helper，统一判断 VLESS Vision flow 是否允许：

1. TLS/Reality 开启，并且传输为默认 TCP（`nil`、`{}` 或 `type: tcp`）时保留 `flow`
2. 未开启 TLS 时移除 `flow`
3. gRPC 等非 TCP 传输移除 `flow`

该判断同时用于入站 users 生成和 JSON/Clash 订阅生成。

### 关联

- Fixes #1156
- Refines #1127

### 测试

15 个用例，覆盖服务端入站 users、订阅 outbounds 和协议 helper。

- VLESS + TLS + TCP 保留 Vision flow
- VLESS + Reality + TCP 保留 Vision flow
- VLESS + gRPC 移除 Vision flow
- VLESS 无 TLS 移除 Vision flow
- 默认/空 transport 按 TCP 处理

`go test ./...`
