### PR TITLE
fix share link pin sha256 fingerprint

### DIFF
--- a/util/genLink.go
+++ b/util/genLink.go
@@ -116,6 +116,9 @@ func prepareTls(t *model.Tls) map[string]interface{} {
 	if err := json.Unmarshal(t.Server, &iTls); err != nil {
 		return nil
 	}
+	if fp := CertSha256Hex(CertPEMFromTLS(iTls)); fp != "" {
+		oTls["certificate_public_key_sha256"] = []string{fp}
+	}
 
 	for k, v := range iTls {
 		switch k {

--- a/util/genLink.go
+++ b/util/genLink.go
@@ -117,7 +117,7 @@ func prepareTls(t *model.Tls) map[string]interface{} {
 		return nil
 	}
 	if fp := CertSha256Hex(CertPEMFromTLS(iTls)); fp != "" {
-		oTls["certificate_public_key_sha256"] = []string{fp}
+		oTls["certificate_public_key_sha256"] = []interface{}{fp}
 	}
 
 	for k, v := range iTls {


### PR DESCRIPTION
## Summary
- Make share-link pinSHA256 use the full certificate SHA256 hex fingerprint.
- Keep sing-box certificate_public_key_sha256 storage unchanged.
- Fix the temporary TLS map value type so pinSHA256 is emitted correctly.