### PR TITLE
Fix Shadowsocks 2022 user lookup

### DIFF
--- a/service/inbounds.go
+++ b/service/inbounds.go
@@ -259,9 +259,7 @@ func (s *InboundService) fetchUsers(db *gorm.DB, inboundType string, condition s
 	}
 	if inboundType == "shadowsocks" {
 		method, _ := inbound["method"].(string)
-		if method == "2022-blake3-aes-128-gcm" {
-			inboundType = "shadowsocks16"
-		}
+		inboundType = util.ShadowsocksClientConfigKey(method)
 	}
 
 	var users []string

--- a/sub/jsonService.go
+++ b/sub/jsonService.go
@@ -140,11 +140,7 @@ func (j *JsonService) getOutbounds(clientConfig json.RawMessage, inbounds []*mod
 				userPass = append(userPass, inbPass)
 			}
 			var pass string
-			if method == "2022-blake3-aes-128-gcm" {
-				pass, _ = configs["shadowsocks16"].(map[string]interface{})["password"].(string)
-			} else {
-				pass, _ = configs["shadowsocks"].(map[string]interface{})["password"].(string)
-			}
+			pass, _ = configs[util.ShadowsocksClientConfigKey(method)].(map[string]interface{})["password"].(string)
 			userPass = append(userPass, pass)
 			outbound["password"] = strings.Join(userPass, ":")
 		} else { // Other protocols

--- a/util/genLink.go
+++ b/util/genLink.go
@@ -170,11 +170,7 @@ func shadowsocksLink(
 		userPass = append(userPass, inbPass)
 	}
 	var pass string
-	if method == "2022-blake3-aes-128-gcm" {
-		pass, _ = userConfig["shadowsocks16"]["password"].(string)
-	} else {
-		pass, _ = userConfig["shadowsocks"]["password"].(string)
-	}
+	pass, _ = userConfig[ShadowsocksClientConfigKey(method)]["password"].(string)
 	userPass = append(userPass, pass)
 
 	uriBase := fmt.Sprintf("ss://%s", toBase64([]byte(fmt.Sprintf("%s:%s", method, strings.Join(userPass, ":")))))

--- a/util/shadowsocks.go
+++ b/util/shadowsocks.go
@@ -1,0 +1,12 @@
+package util
+
+func ShadowsocksClientConfigKey(method string) string {
+	switch method {
+	case "2022-blake3-aes-128-gcm":
+		return "shadowsocks16"
+	case "2022-blake3-aes-256-gcm", "2022-blake3-chacha20-poly1305":
+		return "shadowsocks32"
+	default:
+		return "shadowsocks"
+	}
+}

--- a/util/shadowsocks_test.go
+++ b/util/shadowsocks_test.go
@@ -1,0 +1,19 @@
+package util
+
+import "testing"
+
+func TestShadowsocksClientConfigKey(t *testing.T) {
+	tests := map[string]string{
+		"2022-blake3-aes-128-gcm":       "shadowsocks16",
+		"2022-blake3-aes-256-gcm":       "shadowsocks32",
+		"2022-blake3-chacha20-poly1305": "shadowsocks32",
+		"chacha20-ietf-poly1305":        "shadowsocks",
+		"aes-256-gcm":                   "shadowsocks",
+	}
+
+	for method, want := range tests {
+		if got := ShadowsocksClientConfigKey(method); got != want {
+			t.Fatalf("ShadowsocksClientConfigKey(%q) = %q, want %q", method, got, want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- map all Shadowsocks 2022 methods to the correct client config key when building inbound users
- reuse the same mapping for generated Shadowsocks links and JSON subscription outbounds
- keep legacy Shadowsocks methods on the existing shadowsocks key

Fixes #1178

## Tests
- HTTPS_PROXY=http://127.0.0.1:10808 HTTP_PROXY=http://127.0.0.1:10808 go test ./util
- HTTPS_PROXY=http://127.0.0.1:10808 HTTP_PROXY=http://127.0.0.1:10808 go test ./...

Note: I did not find a PR template under .github in this repository.