### PR TITLE
fix: audit S-UI panel against sing-box v1.13.14 stable — SS plugin and Hysteria port-hopping

### DIFF
--- a/util/genLink.go
+++ b/util/genLink.go
@@ -175,10 +175,21 @@ func shadowsocksLink(
 
 	uriBase := fmt.Sprintf("ss://%s", toBase64([]byte(fmt.Sprintf("%s:%s", method, strings.Join(userPass, ":")))))
 
+	plugin, _ := inbound["plugin"].(string)
+	pluginOpts, _ := inbound["plugin_opts"].(string)
+
 	var links []string
 	for _, addr := range addrs {
 		port, _ := addr["server_port"].(float64)
-		links = append(links, fmt.Sprintf("%s@%s:%.0f#%s", uriBase, addr["server"].(string), port, addr["remark"].(string)))
+		link := fmt.Sprintf("%s@%s:%.0f", uriBase, addr["server"].(string), port)
+		if plugin != "" {
+			link += "?plugin=" + plugin
+			if pluginOpts != "" {
+				link += ";" + pluginOpts
+			}
+		}
+		link += "#" + addr["remark"].(string)
+		links = append(links, link)
 	}
 	return links
 }


### PR DESCRIPTION
## Overview

Audit of S-UI panel against **sing-box v1.13.14 stable** (no alpha/beta changes). All fixes are scoped strictly to what v1.13.14 supports.

## Gaps Found and Fixed

### Shadowsocks outbound: plugin/plugin_opts

**Gap:** `option/shadowsocks.go` (`ShadowsocksOutboundOptions`) has `Plugin string` and `PluginOptions string` fields since at least v1.13.x, but S-UI had:
- No type fields in the TypeScript outbound interface (`Shadowsocks`)
- No UI inputs in `Shadowsocks.vue` for outbound direction
- `genLink.go` `shadowsocksLink()` never emitted `?plugin=name;opts` in share links — breaking round-trip import for plugin-configured SS connections

**Fix:**
- Added `plugin?: string` and `plugin_opts?: string` to `outbounds.ts` `Shadowsocks` interface
- Added plugin/plugin_opts input rows in `Shadowsocks.vue` (outbound only; inbound SS has no plugin in sing-box)
- `genLink.go`: emit `?plugin=name;opts` query param when plugin is configured

### Hysteria outbound: server_ports / hop_interval (port hopping)

**Gap:** `option/hysteria.go` (`HysteriaOutboundOptions`) has `ServerPorts` and `HopInterval` fields for port-hopping, but S-UI had:
- No type fields in the `Hysteria` outbound interface in `outbounds.ts`
- No UI in `Hysteria.vue` — users could not configure port-hopping from the panel

**Fix:**
- Added `server_ports?: string[]` and `hop_interval?: string` to `outbounds.ts` `Hysteria` interface
- Added port-range input, hop interval input, and toggle switch in `Hysteria.vue` options menu (outbound only)

## Scope

No 1.14.x features included. No alpha/beta changes. Only correcting gaps against the existing stable release pinned in `go.mod`.

## Testing Checklist
- [ ] SS outbound with plugin configured — share link includes `?plugin=...`
- [ ] SS import with `?plugin=` param — round-trips correctly (linkToJson.go already handles import)
- [ ] Hysteria outbound with port range — config serializes `server_ports` correctly
- [ ] Hysteria outbound port-hopping toggle hides/shows fields correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)