### PR TITLE
fix: SS plugin share link + VLESS inbound-level flow gate

### DIFF
--- a/sub/jsonService.go
+++ b/sub/jsonService.go
@@ -150,6 +150,10 @@ func (j *JsonService) getOutbounds(clientConfig json.RawMessage, inbounds []*mod
 					continue
 				}
 				if key == "flow" {
+					// Inbound-level flow gate: skip client flow unless out_json.allow_flow is true
+					if allowFlow, _ := outbound["allow_flow"].(bool); !allowFlow {
+						continue
+					}
 					if inData.TlsId == 0 {
 						continue
 					}

--- a/util/genLink.go
+++ b/util/genLink.go
@@ -175,10 +175,28 @@ func shadowsocksLink(
 
 	uriBase := fmt.Sprintf("ss://%s", toBase64([]byte(fmt.Sprintf("%s:%s", method, strings.Join(userPass, ":")))))
 
+	// plugin/plugin_opts are outbound-only fields, stored in out_json
+	var plugin, pluginOpts string
+	var outJson map[string]interface{}
+	if raw, ok := inbound["out_json"].(json.RawMessage); ok {
+		_ = json.Unmarshal(raw, &outJson)
+		plugin, _ = outJson["plugin"].(string)
+		pluginOpts, _ = outJson["plugin_opts"].(string)
+	}
+
 	var links []string
 	for _, addr := range addrs {
 		port, _ := addr["server_port"].(float64)
-		links = append(links, fmt.Sprintf("%s@%s:%.0f#%s", uriBase, addr["server"].(string), port, addr["remark"].(string)))
+		link := fmt.Sprintf("%s@%s:%.0f", uriBase, addr["server"].(string), port)
+		if plugin != "" {
+			pluginVal := plugin
+			if pluginOpts != "" {
+				pluginVal += ";" + pluginOpts
+			}
+			link += "?plugin=" + url.QueryEscape(pluginVal)
+		}
+		link += "#" + addr["remark"].(string)
+		links = append(links, link)
 	}
 	return links
 }

--- a/util/genLink.go
+++ b/util/genLink.go
@@ -421,10 +421,11 @@ func vlessLink(
 	if raw, ok := inbound["out_json"].(json.RawMessage); ok {
 		var outJson map[string]interface{}
 		if json.Unmarshal(raw, &outJson) == nil {
-			if af, ok := outJson["allow_flow"].(bool); ok && af {
-				inboundFlowEnabled = true
+			if af, ok := outJson["allow_flow"]; ok {
+				// Key is present: honour the explicit value
+				inboundFlowEnabled, _ = af.(bool)
 			} else {
-				// Reality TLS implies flow by default even if flag not persisted yet
+				// Key absent: auto-enable for reality TLS (backwards compat)
 				if tls, ok := outJson["tls"].(map[string]interface{}); ok {
 					if reality, ok := tls["reality"].(map[string]interface{}); ok {
 						if enabled, ok := reality["enabled"].(bool); ok && enabled {

--- a/util/genLink.go
+++ b/util/genLink.go
@@ -415,6 +415,27 @@ func vlessLink(
 	if len(baseParams) == 1 && baseParams[0].Value == "tcp" {
 		isTcp = true
 	}
+
+	// Inbound-level flow gate: only allow client flow when out_json.allow_flow is true
+	var inboundFlowEnabled bool
+	if raw, ok := inbound["out_json"].(json.RawMessage); ok {
+		var outJson map[string]interface{}
+		if json.Unmarshal(raw, &outJson) == nil {
+			if af, ok := outJson["allow_flow"].(bool); ok && af {
+				inboundFlowEnabled = true
+			} else {
+				// Reality TLS implies flow by default even if flag not persisted yet
+				if tls, ok := outJson["tls"].(map[string]interface{}); ok {
+					if reality, ok := tls["reality"].(map[string]interface{}); ok {
+						if enabled, ok := reality["enabled"].(bool); ok && enabled {
+							inboundFlowEnabled = true
+						}
+					}
+				}
+			}
+		}
+	}
+
 	var links []string
 
 	for _, addr := range addrs {
@@ -422,7 +443,7 @@ func vlessLink(
 		copy(params, baseParams)
 		if tls, ok := addr["tls"].(map[string]interface{}); ok && tls["enabled"].(bool) {
 			getTlsParams(&params, tls, "vless")
-			if flow, ok := userConfig["flow"].(string); ok && isTcp {
+			if flow, ok := userConfig["flow"].(string); ok && flow != "" && isTcp && inboundFlowEnabled {
 				params = append(params, LinkParam{"flow", flow})
 			}
 		}

--- a/util/genLink_test.go
+++ b/util/genLink_test.go
@@ -1,0 +1,99 @@
+package util
+
+import (
+	"encoding/json"
+	"net/url"
+	"strings"
+	"testing"
+)
+
+func TestShadowsocksLinkPlugin(t *testing.T) {
+	userConfig := map[string]map[string]interface{}{
+		"shadowsocks": {"password": "testpass"},
+	}
+	inbound := map[string]interface{}{
+		"method": "aes-256-gcm",
+	}
+	addrs := []map[string]interface{}{
+		{"server": "1.2.3.4", "server_port": float64(8388), "remark": "test"},
+	}
+
+	// Without plugin (no out_json at all)
+	links := shadowsocksLink(userConfig, inbound, addrs)
+	if len(links) != 1 {
+		t.Fatalf("expected 1 link, got %d", len(links))
+	}
+	if strings.Contains(links[0], "?plugin=") {
+		t.Errorf("link should not contain plugin param: %s", links[0])
+	}
+	if !strings.HasSuffix(links[0], "#test") {
+		t.Errorf("link should end with #test: %s", links[0])
+	}
+
+	// With plugin + opts in out_json (as the real panel stores them)
+	outJson := map[string]interface{}{
+		"plugin":      "v2ray-plugin",
+		"plugin_opts": "server;tls;host=example.com",
+	}
+	outJsonBytes, _ := json.Marshal(outJson)
+	inbound["out_json"] = json.RawMessage(outJsonBytes)
+
+	links = shadowsocksLink(userConfig, inbound, addrs)
+	if !strings.HasSuffix(links[0], "#test") {
+		t.Errorf("link should end with #test: %s", links[0])
+	}
+	// Verify URL round-trip: semicolons must survive url.ParseQuery
+	u, err := url.Parse(links[0])
+	if err != nil {
+		t.Fatalf("generated link is not a valid URL: %s", err)
+	}
+	q, _ := url.ParseQuery(u.RawQuery)
+	pluginVal := q.Get("plugin")
+	if pluginVal != "v2ray-plugin;server;tls;host=example.com" {
+		t.Errorf("plugin param should survive URL round-trip, got: %q from link: %s", pluginVal, links[0])
+	}
+
+	// Full round-trip via GetOutbound (the actual import path)
+	outbound, tag, err := GetOutbound(links[0], 0)
+	if err != nil {
+		t.Fatalf("GetOutbound failed: %s", err)
+	}
+	if tag != "test" {
+		t.Errorf("tag should be 'test', got: %q", tag)
+	}
+	ob := *outbound
+	if ob["plugin"] != "v2ray-plugin" {
+		t.Errorf("round-trip plugin name should be 'v2ray-plugin', got: %q", ob["plugin"])
+	}
+	if ob["plugin_opts"] != "server;tls;host=example.com" {
+		t.Errorf("round-trip plugin_opts should be 'server;tls;host=example.com', got: %q", ob["plugin_opts"])
+	}
+
+	// Plugin without opts
+	outJson = map[string]interface{}{"plugin": "v2ray-plugin"}
+	outJsonBytes, _ = json.Marshal(outJson)
+	inbound["out_json"] = json.RawMessage(outJsonBytes)
+
+	links = shadowsocksLink(userConfig, inbound, addrs)
+	outbound, _, err = GetOutbound(links[0], 0)
+	if err != nil {
+		t.Fatalf("GetOutbound failed for plugin-only: %s", err)
+	}
+	ob = *outbound
+	if ob["plugin"] != "v2ray-plugin" {
+		t.Errorf("plugin-only round-trip name should be 'v2ray-plugin', got: %q", ob["plugin"])
+	}
+	if opts, ok := ob["plugin_opts"].(string); ok && opts != "" {
+		t.Errorf("plugin-only round-trip should have empty opts, got: %q", opts)
+	}
+
+	// Empty out_json (no plugin)
+	outJson = map[string]interface{}{}
+	outJsonBytes, _ = json.Marshal(outJson)
+	inbound["out_json"] = json.RawMessage(outJsonBytes)
+
+	links = shadowsocksLink(userConfig, inbound, addrs)
+	if strings.Contains(links[0], "?plugin=") {
+		t.Errorf("empty out_json should not produce plugin param: %s", links[0])
+	}
+}

--- a/util/genLink_test.go
+++ b/util/genLink_test.go
@@ -97,3 +97,67 @@ func TestShadowsocksLinkPlugin(t *testing.T) {
 		t.Errorf("empty out_json should not produce plugin param: %s", links[0])
 	}
 }
+
+func TestVlessFlowGate(t *testing.T) {
+	userConfigWithFlow := map[string]interface{}{
+		"uuid": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+		"flow": "xtls-rprx-vision",
+	}
+	userConfigNoFlow := map[string]interface{}{
+		"uuid": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+	}
+	addrs := []map[string]interface{}{
+		{
+			"server":      "1.2.3.4",
+			"server_port": float64(443),
+			"remark":      "test",
+			"tls": map[string]interface{}{
+				"enabled": true,
+				"reality": map[string]interface{}{"enabled": true},
+			},
+		},
+	}
+
+	makeInbound := func(realityEnabled bool, allowFlow interface{}) map[string]interface{} {
+		reality := map[string]interface{}{"enabled": realityEnabled}
+		tls := map[string]interface{}{"reality": reality}
+		outJsonMap := map[string]interface{}{"tls": tls}
+		if allowFlow != nil {
+			outJsonMap["allow_flow"] = allowFlow
+		}
+		b, _ := json.Marshal(outJsonMap)
+		return map[string]interface{}{"out_json": json.RawMessage(b)}
+	}
+
+	getFlow := func(link string) string {
+		u, _ := url.Parse(link)
+		q, _ := url.ParseQuery(u.RawQuery)
+		return q.Get("flow")
+	}
+
+	// no out_json at all — flow must be absent even with user flow set
+	links := vlessLink(userConfigWithFlow, map[string]interface{}{}, addrs)
+	if getFlow(links[0]) != "" {
+		t.Errorf("no out_json: flow should be absent, got: %s", links[0])
+	}
+
+	// allow_flow = false explicitly — flow suppressed
+	if getFlow(vlessLink(userConfigWithFlow, makeInbound(true, false), addrs)[0]) != "" {
+		t.Errorf("allow_flow=false: flow should be absent")
+	}
+
+	// allow_flow = true explicitly — flow present
+	if getFlow(vlessLink(userConfigWithFlow, makeInbound(true, true), addrs)[0]) != "xtls-rprx-vision" {
+		t.Errorf("allow_flow=true: flow should be 'xtls-rprx-vision'")
+	}
+
+	// reality enabled + no allow_flow flag — backwards compat defaults to enabled
+	if getFlow(vlessLink(userConfigWithFlow, makeInbound(true, nil), addrs)[0]) != "xtls-rprx-vision" {
+		t.Errorf("reality+no allow_flow: flow should default to 'xtls-rprx-vision'")
+	}
+
+	// allow_flow = true but user has no flow value — param must be absent
+	if getFlow(vlessLink(userConfigNoFlow, makeInbound(true, true), addrs)[0]) != "" {
+		t.Errorf("allow_flow=true, no user flow: flow param should be absent")
+	}
+}

--- a/util/outJson.go
+++ b/util/outJson.go
@@ -221,6 +221,16 @@ func vlessOut(out *map[string]interface{}, inbound map[string]interface{}) {
 	if transport, ok := inbound["transport"]; ok {
 		(*out)["transport"] = transport
 	}
+	// Default allow_flow on when TLS reality is enabled (vision flow is standard with reality)
+	if _, exists := (*out)["allow_flow"]; !exists {
+		if tls, ok := (*out)["tls"].(map[string]interface{}); ok {
+			if reality, ok := tls["reality"].(map[string]interface{}); ok {
+				if enabled, ok := reality["enabled"].(bool); ok && enabled {
+					(*out)["allow_flow"] = true
+				}
+			}
+		}
+	}
 }
 
 func trojanOut(out *map[string]interface{}, inbound map[string]interface{}) {


### PR DESCRIPTION
## Summary

- **SS share link — plugin URL encoding**: Fixed `plugin` and `plugin_opts` being read from `out_json` (outbound-only storage, not the inbound map). Also fixed raw `;` in the query string silently splitting plugin options (`url.ParseQuery` treats `;` as `&`); now uses `url.QueryEscape()` on the concatenated `name;opts` string.
- **VLESS inbound-level flow gate**: Added `out_json.allow_flow` boolean as the inbound-level control. Client `flow` is only emitted in share links and JSON subscriptions when the inbound gate is on.
  - Gate is checked in `vlessLink()` (share links) and `jsonService.go` (JSON subscription).
  - `vlessOut()` auto-defaults `allow_flow = true` when reality TLS is detected (xtls-rprx-vision is standard practice for reality).
  - Fallback in `genLink.go` reads `reality.enabled` from `out_json.tls` for existing inbounds without the flag.
- Flow priority: inbound OFF → no flow regardless of client; inbound ON + client has flow → flow emitted; inbound ON + client has no flow → no flow.

## Test plan

- [ ] SS proxy with `v2ray-plugin;opts` — share link encodes plugin correctly, round-trips via `GetOutbound()`
- [ ] SS proxy without plugin — no `plugin` param in share link
- [ ] VLESS + reality inbound (`allow_flow = true` by default) + client flow set → flow appears in share link and JSON sub
- [ ] VLESS + reality inbound + `allow_flow` toggled OFF → flow absent regardless of client config
- [ ] VLESS + non-TCP transport (WS/gRPC) → flow absent even when `allow_flow = true`
- [ ] `go test ./...` passes

Frontend toggle for `allow_flow` is in the companion PR on s-ui-frontend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)