### PR TITLE
Add tokenless addTraffic endpoint for external usage reporting

### DIFF
--- a/api/apiAddTraffic.go
+++ b/api/apiAddTraffic.go
@@ -1,0 +1,25 @@
+package api
+
+import (
+	"encoding/json"
+
+	"github.com/gin-gonic/gin"
+)
+
+// AddTraffic handles POST <web_base_url>/api/addTraffic and
+// <web_base_url>/apiv2/addTraffic, where <web_base_url> is the user-configured
+// panel base path.
+// Body (form field "data"): {"name":"<client>","up":<bytes>,"down":<bytes>}
+//
+// Deliberately tokenless: the endpoint is write-only and can ONLY add positive
+// bytes to an EXISTING client. It cannot read data, disable clients, or reduce
+// counters. If abuse appears, consider HMAC(secret, name); the secret would
+// never leave the server.
+func (a *ApiService) AddTraffic(c *gin.Context) {
+	data := c.Request.FormValue("data")
+	if err := a.ClientService.AddTraffic(json.RawMessage(data)); err != nil {
+		jsonMsg(c, "addTraffic", err)
+		return
+	}
+	jsonMsg(c, "addTraffic", nil)
+}

--- a/api/apiHandler.go
+++ b/api/apiHandler.go
@@ -48,6 +48,8 @@ func (a *APIHandler) postHandler(c *gin.Context) {
 		a.ApiService.RestartSb(c)
 	case "resetTraffic":
 		a.ApiService.ResetTraffic(c)
+	case "addTraffic":
+		a.ApiService.AddTraffic(c)
 	case "linkConvert":
 		a.ApiService.LinkConvert(c)
 	case "subConvert":

--- a/service/clientAddTraffic.go
+++ b/service/clientAddTraffic.go
@@ -1,0 +1,56 @@
+package service
+
+import (
+	"encoding/json"
+	"time"
+
+	"github.com/alireza0/s-ui/database"
+	"github.com/alireza0/s-ui/database/model"
+	"github.com/alireza0/s-ui/logger"
+
+	"gorm.io/gorm"
+)
+
+// AddTraffic atomically adds up/down deltas to a client matched by name.
+// Used by external clients (e.g. a custom Android app) to report locally
+// measured usage. Security model (tokenless by design):
+//   - deltas must be >= 0 (counters can never be reduced or reset here)
+//   - unknown names are rejected (RowsAffected == 0 -> ErrRecordNotFound)
+//   - endpoint exposes nothing to read and cannot enable/disable clients
+type trafficDelta struct {
+	Name string `json:"name"`
+	Up   int64  `json:"up"`
+	Down int64  `json:"down"`
+}
+
+func (s *ClientService) AddTraffic(data json.RawMessage) error {
+	var d trafficDelta
+	if err := json.Unmarshal(data, &d); err != nil {
+		return err
+	}
+	if d.Name == "" {
+		return gorm.ErrRecordNotFound
+	}
+	if d.Up < 0 || d.Down < 0 {
+		return gorm.ErrInvalidData
+	}
+	if d.Up == 0 && d.Down == 0 {
+		return nil
+	}
+	db := database.GetDB()
+	res := db.Model(model.Client{}).
+		Where("name = ?", d.Name).
+		Updates(map[string]interface{}{
+			"up":        gorm.Expr("up + ?", d.Up),
+			"down":      gorm.Expr("down + ?", d.Down),
+			"online_at": time.Now().Unix(),
+		})
+	if res.Error != nil {
+		logger.Warning("addTraffic failed for", d.Name, ":", res.Error)
+		return res.Error
+	}
+	if res.RowsAffected == 0 {
+		return gorm.ErrRecordNotFound
+	}
+	return nil
+}

--- a/web/web.go
+++ b/web/web.go
@@ -107,6 +107,10 @@ func (s *Server) initRouter() (*gin.Engine, error) {
 	group_apiv2 := engine.Group(base_url + "apiv2")
 	apiv2 := api.NewAPIv2Handler(group_apiv2)
 
+	// Tokenless usage reporting: write-only, positive-delta-only.
+	// Registered before the group so the static path wins over /:postAction.
+	engine.POST(base_url+"apiv2/addTraffic", apiv2.ApiService.AddTraffic)
+
 	group_api := engine.Group(base_url + "api")
 	api.NewAPIHandler(group_api, apiv2)
 


### PR DESCRIPTION
Hi! Thanks for maintaining s-ui.

This PR adds a small write-only endpoint that lets an external client report locally measured usage for one client by name:

```
POST <web_base_url>/apiv2/addTraffic
data={"name":"<client>","up":<bytes>,"down":<bytes>}
```

`<web_base_url>` is the user-configured panel base path (the same prefix as the login page — `/`, `/sub/`, `/panel/`, ...).

Motivation: I use s-ui together with a custom Android VPN app whose traffic does not pass through this panel's sing-box inbounds, so the server never sees that usage. The app measures traffic itself and pushes accumulated deltas here every few minutes.

Design notes — deliberately tokenless:
- the endpoint is write-only: it can ONLY add positive deltas (`up`/`down`) to an EXISTING client matched by name
- counters can never be reduced or reset through this route
- unknown names are rejected; nothing is exposed to read
- it cannot enable/disable clients or touch any other field

Implementation:
- `service/clientAddTraffic.go` — atomic `up += x`, `down += y` via `gorm.Expr`, plus `online_at` refresh
- `api/apiAddTraffic.go` — handler (form field `data`)
- registered in `web/web.go` outside the authenticated v2 group on purpose (static route wins over `/:postAction`), and also exposed in the cookie-authenticated `/api` switch

Happy to adjust naming/validation if you'd prefer a different shape. Thank you!
