### PR TITLE
Remove stale quic options from naive out_json when congestion control is cleared

### DIFF
--- a/util/outJson.go
+++ b/util/outJson.go
@@ -129,7 +129,10 @@ func addTls(out *map[string]interface{}, tls *model.Tls) {
 }
 
 func naiveOut(out *map[string]interface{}, inbound map[string]interface{}) {
-	if quic_congestion_control, ok := inbound["quic_congestion_control"].(string); ok {
+	delete(*out, "quic")
+	delete(*out, "quic_congestion_control")
+
+	if quic_congestion_control, ok := inbound["quic_congestion_control"].(string); ok && quic_congestion_control != "" {
 		(*out)["quic"] = true
 		switch quic_congestion_control {
 		case "bbr_standard":

--- a/util/outJson_test.go
+++ b/util/outJson_test.go
@@ -1,0 +1,60 @@
+package util
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/alireza0/s-ui/database/model"
+)
+
+// https://github.com/alireza0/s-ui/issues/1243
+// Editing a naive inbound and clearing QUIC Congestion Control must remove
+// the stale quic / quic_congestion_control keys from the stored out_json.
+func TestFillOutJsonNaiveClearsStaleQuic(t *testing.T) {
+	inbound := &model.Inbound{
+		Type:    "naive",
+		Tag:     "naive-in",
+		Options: json.RawMessage(`{"listen_port": 443}`),
+		// out_json left over from a previous save with QUIC enabled
+		OutJson: json.RawMessage(`{"quic": true, "quic_congestion_control": "bbr"}`),
+	}
+
+	if err := FillOutJson(inbound, "example.com"); err != nil {
+		t.Fatal(err)
+	}
+
+	var out map[string]interface{}
+	if err := json.Unmarshal(inbound.OutJson, &out); err != nil {
+		t.Fatal(err)
+	}
+	if v, ok := out["quic"]; ok {
+		t.Errorf("quic should be removed when quic_congestion_control is cleared, got %v", v)
+	}
+	if v, ok := out["quic_congestion_control"]; ok {
+		t.Errorf("quic_congestion_control should be removed when cleared, got %v", v)
+	}
+}
+
+func TestFillOutJsonNaiveSetsQuic(t *testing.T) {
+	inbound := &model.Inbound{
+		Type:    "naive",
+		Tag:     "naive-in",
+		Options: json.RawMessage(`{"listen_port": 443, "quic_congestion_control": "bbr_standard"}`),
+		OutJson: json.RawMessage(`{}`),
+	}
+
+	if err := FillOutJson(inbound, "example.com"); err != nil {
+		t.Fatal(err)
+	}
+
+	var out map[string]interface{}
+	if err := json.Unmarshal(inbound.OutJson, &out); err != nil {
+		t.Fatal(err)
+	}
+	if out["quic"] != true {
+		t.Errorf("quic = %v, want true", out["quic"])
+	}
+	if out["quic_congestion_control"] != "bbr" {
+		t.Errorf("quic_congestion_control = %v, want bbr (mapped from bbr_standard)", out["quic_congestion_control"])
+	}
+}


### PR DESCRIPTION
Fixes #1243

**Problem**

Editing an existing naive inbound and clearing the QUIC Congestion Control field left `"quic": true` and the old `"quic_congestion_control"` in the generated out_json, so clients kept using QUIC.

**Cause**

`FillOutJson` unmarshals the previously stored `out_json` and merges into it. When the field is cleared, the frontend deletes `quic_congestion_control` from the inbound settings (`@click:clear` in `Naive.vue`), so `naiveOut` takes no action — and the stale keys from the previous save survive. Every other helper there (`hysteriaOut`, `hysteria2Out`, `tuicOut`, `vlessOut`, ...) deletes its stale keys first; `naiveOut` was the only one that didn't.

**Fix**

Delete `quic` / `quic_congestion_control` at the top of `naiveOut`, same pattern as the sibling helpers. Also skip an empty-string value, which the frontend type allows.

**Verification**

- Added `util/outJson_test.go` (stdlib `testing`, per CONTRIBUTING): one test reproducing the stale-key case (fails on `main`, passes with this change), one covering the set case including the `bbr_standard` → `bbr` mapping.
- `gofmt`, `go vet ./util/`, and the full tagged build (`with_quic,with_grpc,...`) pass.

Written with Claude Code.